### PR TITLE
Update update_metadata.yml

### DIFF
--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -23,10 +23,10 @@ jobs:
           branch: metadata-updates
           delete-branch: true
       - name: Await Check Suites
-        uses: jitterbit/await-check-suites@v1
+        uses: armory-io/wait-for-required-status-checks@master
         with:
-          ref: refs/heads/metadata-updates
           token: ${{ secrets.ASTROLABE_GITHUB_TOKEN }}
+          pull_request_number: ${{ steps.create-pull-request.outputs.pull-request-number }}
       - name: Merge Pull Request
         uses: sudo-bot/action-pull-request-merge@v1.1.1
         with:


### PR DESCRIPTION
The action I was using to block on status checks doesn't work in this repo (no clue why) and doesn't log any errors. I re-wrote it so we'd have control over it / better error handling.